### PR TITLE
slow down the clock of GPIO pins for SPI

### DIFF
--- a/Custom_Panel_RevC/Arduino/variants/NTS1_REF_CP_REVC/nts1_iface.c
+++ b/Custom_Panel_RevC/Arduino/variants/NTS1_REF_CP_REVC/nts1_iface.c
@@ -265,7 +265,7 @@ static inline void s_spi_enable_pins()
   /* Enable SCK, MOSI, MISO. No NSS. */
   /* Peripherals alternate function */
   gpio.Mode = GPIO_MODE_AF_PP;
-  gpio.Speed = GPIO_SPEED_FREQ_HIGH;
+  gpio.Speed = GPIO_SPEED_FREQ_LOW;
   gpio.Pull = GPIO_NOPULL;
   gpio.Alternate = SPI_GPIO_AF;
   


### PR DESCRIPTION
This PR fixes unstable SPI communication. GPIO_SPEED_FREQ_HIGH is for range 10 MHz to 50 MHz communication and is too fast for the communication between NTS1 main board and control panel (its speed is 1MHz).
I experienced SPI communication trouble when I connected a Nucleo-F030 board to NTS1. Slowing down the GPIO pin clock made the communication stable.