### PR TITLE
nts1_iface.c: add aligned atrtribute to s_rx_event_decode_buf

### DIFF
--- a/Custom_Panel_RevC/Arduino/variants/NTS1_REF_CP_REVC/nts1_iface.c
+++ b/Custom_Panel_RevC/Arduino/variants/NTS1_REF_CP_REVC/nts1_iface.c
@@ -390,7 +390,7 @@ static uint8_t s_tx_cmd_other_bootmode(uint8_t endmark)
 
 static uint8_t s_dummy_buffer[64];
 #define RX_EVENT_MAX_DECODE_SIZE 64
-static uint8_t s_rx_event_decode_buf[RX_EVENT_MAX_DECODE_SIZE] = {0};
+static uint8_t s_rx_event_decode_buf[RX_EVENT_MAX_DECODE_SIZE] __attribute__((aligned)) = {0};
 
 static void s_rx_msg_handler(uint8_t data)
 {


### PR DESCRIPTION
Issue: The following sketch does not work. 
In the message handler `rx_value()`,  `val->value` causes system crash.
I suspected this is a memory alignment problem, and added `__attribute__((aligned))` to `s_rx_event_decode_buf` in `nts1_iface.c`. Then it seems to work correctly.
```
#include <nts-1.h>

NTS1 nts1;

void rx_value(const nts1_rx_value_t *val) {
  Serial.print("req_id = ");
  Serial.println(val->req_id);
  Serial.print("value = ");
  Serial.println(val->value); // this line doesn't work!
}

void setup() {
  Serial.begin(9600);
  Serial.println("Start!");

  nts1.init(); 
  nts1.setValueEventHandler((nts1_value_event_handler) rx_value);
  nts1.reqOscCount();
}
void loop() {
  nts1.idle();
}
```
